### PR TITLE
Updated params for inference_realesrgan.py

### DIFF
--- a/360Diffusion_Simplified-Demo.ipynb
+++ b/360Diffusion_Simplified-Demo.ipynb
@@ -1,36 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "360Diffusion_Simplified-Demo.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "collapsed_sections": [
-        "1YwMUyt9LHG1",
-        "I6Vt-98xGZVu",
-        "WnN6j5WzvFHg",
-        "xc1W6_SAAvJU",
-        "u4Ut78Lol7EN"
-      ],
-      "machine_shape": "hm",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/sadnow/360Diffusion/blob/main/360Diffusion_Simplified-Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -62,10 +36,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "FpZczxnOnPIU",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "FpZczxnOnPIU"
       },
+      "outputs": [],
       "source": [
         "#@title  { form-width: \"100px\" }\n",
         "\n",
@@ -112,10 +88,10 @@
         "  else:\n",
         "    return True\n",
         "\n",
-        "def image_upscale(model_path,scale,input,output):\n",
-        "    %cd /content/Real-ESRGAN/\n",
-        "    !python inference_realesrgan.py --model_path $model_path --netscale $scale --face_enhance --input $input --output $output --ext jpg\n",
-        "    %cd /content/\n",
+        "#def image_upscale(model_path,scale,input,output):\n",
+        "#    %cd /content/Real-ESRGAN/\n",
+        "#    !python inference_realesrgan.py --model_path $model_path --netscale $scale --face_enhance --input $input --output $output --ext jpg\n",
+        "#    %cd /content/\n",
         "\n",
         "##@title Choose model here:\n",
         "# diffusion_model = \"256x256_diffusion_uncond\" #@param [\"256x256_diffusion_uncond\", \"512x512_diffusion_uncond_finetune_008100\"]\n",
@@ -166,11 +142,11 @@
         "    !pip install -r requirements.txt -q\n",
         "    %cd /content/Real-ESRGAN\n",
         "    !python setup.py develop -q\n",
-        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models\n",
-        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth -P experiments/pretrained_models\n",
-        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth -P experiments/pretrained_models\n",
-        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth -P experiments/pretrained_models\n",
-        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/ESRGAN_SRx4_DF2KOST_official-ff704c30.pth -P experiments/pretrained_models  #regular esrgan\n",
+        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models\n",
+        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth -P experiments/pretrained_models\n",
+        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth -P experiments/pretrained_models\n",
+        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth -P experiments/pretrained_models\n",
+        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/ESRGAN_SRx4_DF2KOST_official-ff704c30.pth -P experiments/pretrained_models  #regular esrgan\n",
         "\n",
         "\n",
         "    print(\"Finished Installing libraries for Real-ESRGAN upscaling.\")\n",
@@ -695,16 +671,16 @@
         "clip_size = clip_model.visual.input_resolution\n",
         "normalize = T.Normalize(mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711])\n",
         "lpips_model = lpips.LPIPS(net='vgg').to(device)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "U0PwzFZbLfcy",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "U0PwzFZbLfcy"
       },
+      "outputs": [],
       "source": [
         "########################################################################\n",
         "#INITIAL VALUES\n",
@@ -767,7 +743,7 @@
         "_project_name = 'images' #@param{type:\"string\"}\n",
         "global _debug_mode\n",
         "_debug_mode = False\n",
-        "_upscale_model='RealESRGAN 4x'\n",
+        "_upscale_model='RealESRGAN_x4plus' #valid values (March 2022): RealESRGAN_x4plus, RealESRNet_x4plus, RealESRGAN_x2plus\n",
         "_target_resolution = \"1024\"\n",
         "_skip_upscaling = False\n",
         "display_rate =  2\n",
@@ -874,13 +850,13 @@
         "#---------------------------------\n",
         "# UPSCALING\n",
         "msg_runtime = msg_runtime + 'Upscaler model: ' + _upscale_model + '; Target resolution: ' + str(_target_resolution) + ' \\n'\n",
-        "if _upscale_model == '(Regular) ESRGAN 4x': _upscale_model = 'ESRGAN_SRx4_DF2KOST_official-ff704c30.pth'\n",
-        "if _upscale_model == 'RealESR_NET 4x': _upscale_model = 'RealESRNet_x4plus.pth'\n",
-        "if _upscale_model == 'RealESRGAN 2x': _upscale_model = 'RealESRGAN_x2plus.pth'\n",
-        "if _upscale_model == 'RealESRGAN 4x': _upscale_model = 'RealESRGAN_x4plus.pth'\n",
-        "if _upscale_model == 'RealESRGAN x4 Anime_6B': _upscale_model = 'RealESRGAN_x4plus_anime_6B.pth'\n",
-        "upscale_model_fullpath='/content/Real-ESRGAN/experiments/pretrained_models/' + _upscale_model\n",
-        "if upscale_model_fullpath == '/content/Real-ESRGAN/experiments/pretrained_models/RealESRGAN_x2plus.pth': upscale_value=\"2\"\n",
+        "#if _upscale_model == '(Regular) ESRGAN 4x': _upscale_model = 'c-ff704c30.pth'\n",
+        "#if _upscale_model == 'RealESR_NET 4x': _upscale_model = 'RealESRNet_x4plus.pth'\n",
+        "#if _upscale_model == 'RealESRGAN_x2plus': _upscale_model = 'RealESRGAN_x2plus.pth'\n",
+        "#if _upscale_model == 'RealESRGAN 4x': _upscale_model = 'RealESRGAN_x4plus.pth'\n",
+        "#if _upscale_model == 'RealESRGAN x4 Anime_6B': _upscale_model = 'RealESRGAN_x4plus_anime_6B.pth'\n",
+        "#upscale_model_fullpath='/content/Real-ESRGAN/experiments/pretrained_models/' + _upscale_model\n",
+        "if _upscale_model == 'RealESRGAN_x2plus': upscale_value=\"2\"\n",
         "#else: upscale_value=\"4\"\n",
         " \n",
         "\n",
@@ -1005,7 +981,7 @@
         "    \n",
         "    if (int(model_size) * int(float(_outscale)) * (int(needed_passes) ** 2)) > int(_target_resolution):\n",
         "      next_outscale = 2\n",
-        "    if not _upscale_model == 'RealESRGAN 2x' and next_outscale == 0:\n",
+        "    if not _upscale_model == 'RealESRGAN_x2plus' and next_outscale == 0:\n",
         "      end_flag = end_flag + '--outscale ' + _outscale + ' '\n",
         "    else:\n",
         "      if completed_passes + 1 == needed_passes:\n",
@@ -1014,7 +990,7 @@
         "    if end_flag.endswith(' '): end_flag = end_flag[:-1] #removes extra space\n",
         "\n",
         "    if not upscale_complete:\n",
-        "      !python inference_realesrgan.py --model_path $upscale_model_fullpath --output $output_folder_images --tile $_esrgan_tilesize --ext $output_extension $end_flag\n",
+        "      !python inference_realesrgan.py --model_name $_upscale_model --output $output_folder_images --tile $_esrgan_tilesize --ext $output_extension $end_flag\n",
         "    \n",
         "\n",
         "    # if double_pass: completed_passes = completed_passes + 1\n",
@@ -1070,9 +1046,7 @@
         "    torch.cuda.empty_cache()\n",
         "\n",
         "###############################################"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1330,5 +1304,31 @@
         ",'outrun'*"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [
+        "1YwMUyt9LHG1",
+        "I6Vt-98xGZVu",
+        "WnN6j5WzvFHg",
+        "xc1W6_SAAvJU",
+        "u4Ut78Lol7EN"
+      ],
+      "include_colab_link": true,
+      "machine_shape": "hm",
+      "name": "360Diffusion_Simplified-Demo.ipynb",
+      "private_outputs": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/360Diffusion_Simplified-Demo.ipynb
+++ b/360Diffusion_Simplified-Demo.ipynb
@@ -3,6 +3,16 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/juanalonso/360Diffusion/blob/main/360Diffusion_Simplified-Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "tkav03SvGq7g"
       },
       "source": [
@@ -667,6 +677,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "cellView": "form",
         "id": "U0PwzFZbLfcy"
       },
       "outputs": [],
@@ -684,7 +695,7 @@
         "skip_augs = False # False - Controls whether to skip torchvision augmentations\n",
         "randomize_class = True # True - Controls whether the imagenet class is randomly changed each iteration\n",
         "#############################################################################################\n",
-        "_text_prompt =  \"The sound of a pull request\" #@param {type:\"string\"} \n",
+        "_text_prompt =  \"'College Campus' art piece inspired by Edward Hopper\" #@param {type:\"string\"} \n",
         "\n",
         "_batch_genetics = False #future implementation\n",
         "_init_genetics = False  #not currently implemented\n",
@@ -723,7 +734,7 @@
         "_image_prompts = \"\"\n",
         "_init_scale = 1000\n",
         "skip_timesteps = 5\n",
-        "n_batches =  1#@param{type:\"raw\"}\n",
+        "n_batches =  50#@param{type:\"raw\"}\n",
         "  #Controls the starting point along the diffusion timesteps\n",
         "\n",
         "##@markdown `Generation Settings`\n",
@@ -1307,7 +1318,8 @@
       "machine_shape": "hm",
       "name": "360Diffusion_Simplified-Demo.ipynb",
       "private_outputs": true,
-      "provenance": []
+      "provenance": [],
+      "include_colab_link": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/360Diffusion_Simplified-Demo.ipynb
+++ b/360Diffusion_Simplified-Demo.ipynb
@@ -3,16 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/sadnow/360Diffusion/blob/main/360Diffusion_Simplified-Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "tkav03SvGq7g"
       },
       "source": [
@@ -142,10 +132,10 @@
         "    !pip install -r requirements.txt -q\n",
         "    %cd /content/Real-ESRGAN\n",
         "    !python setup.py develop -q\n",
-        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models\n",
+        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models\n",
         "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth -P experiments/pretrained_models\n",
         "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth -P experiments/pretrained_models\n",
-        "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth -P experiments/pretrained_models\n",
+        "    !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth -P experiments/pretrained_models\n",
         "    # !wget -nc https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/ESRGAN_SRx4_DF2KOST_official-ff704c30.pth -P experiments/pretrained_models  #regular esrgan\n",
         "\n",
         "\n",
@@ -677,7 +667,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "id": "U0PwzFZbLfcy"
       },
       "outputs": [],
@@ -695,7 +684,7 @@
         "skip_augs = False # False - Controls whether to skip torchvision augmentations\n",
         "randomize_class = True # True - Controls whether the imagenet class is randomly changed each iteration\n",
         "#############################################################################################\n",
-        "_text_prompt =  \"'College Campus' art piece inspired by Edward Hopper\" #@param {type:\"string\"} \n",
+        "_text_prompt =  \"The sound of a pull request\" #@param {type:\"string\"} \n",
         "\n",
         "_batch_genetics = False #future implementation\n",
         "_init_genetics = False  #not currently implemented\n",
@@ -734,7 +723,7 @@
         "_image_prompts = \"\"\n",
         "_init_scale = 1000\n",
         "skip_timesteps = 5\n",
-        "n_batches =  50#@param{type:\"raw\"}\n",
+        "n_batches =  1#@param{type:\"raw\"}\n",
         "  #Controls the starting point along the diffusion timesteps\n",
         "\n",
         "##@markdown `Generation Settings`\n",
@@ -743,7 +732,7 @@
         "_project_name = 'images' #@param{type:\"string\"}\n",
         "global _debug_mode\n",
         "_debug_mode = False\n",
-        "_upscale_model='RealESRGAN_x4plus' #valid values (March 2022): RealESRGAN_x4plus, RealESRNet_x4plus, RealESRGAN_x2plus\n",
+        "_upscale_model='RealESRGAN_x4plus'\n",
         "_target_resolution = \"1024\"\n",
         "_skip_upscaling = False\n",
         "display_rate =  2\n",
@@ -1315,7 +1304,6 @@
         "xc1W6_SAAvJU",
         "u4Ut78Lol7EN"
       ],
-      "include_colab_link": true,
       "machine_shape": "hm",
       "name": "360Diffusion_Simplified-Demo.ipynb",
       "private_outputs": true,


### PR DESCRIPTION
The upscaler (inference_realesrgan.py) now uses a different param for the upscaling model (--model_name , just a name, instead of --model_path, the path to the pth file). I've updated the code to reflect this: without this fix, the colab can not upscale and save the generated image.